### PR TITLE
ci: Fix coverage file path

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: generated/cover.out
+          files: coverage.out
 
   vulncheck:
     name: Vulnerability Check


### PR DESCRIPTION
Currently CI still works as it still checks the default path. But notes that the requested path wasn't found.